### PR TITLE
Fix: link with class `related-widget-wrapper-link` should pop up

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 
 unreleased
 ==========
+* fix: add `data-popup="yes"` to the link with class `related-widget-wrapper-link`, then the popup will be shown when the user clicks on the link. 
+  The JS logic got changed after Django 4.1 upgrade (#15301)
 
 1.6.0 (2024-05-16)
 ==================

--- a/djangocms_content_expiry/templates/djangocms_content_expiry/admin/icons/additional_content_settings_icon.html
+++ b/djangocms_content_expiry/templates/djangocms_content_expiry/admin/icons/additional_content_settings_icon.html
@@ -1,5 +1,5 @@
 {% load static i18n %}
 
-<a class="btn cms-versioning-action-btn related-widget-wrapper-link" id="additional_content_settings_expiry_id_{{ field_id }}" href="{{ url }}" title="{% trans 'Additional Content Settings' %}">
+<a class="btn cms-versioning-action-btn related-widget-wrapper-link" data-popup="yes" id="additional_content_settings_expiry_id_{{ field_id }}" href="{{ url }}" title="{% trans 'Additional Content Settings' %}">
     <img src="{% static 'djangocms_content_expiry/svg/file.svg' %}">
 </a>

--- a/djangocms_content_expiry/templates/djangocms_content_expiry/calendar_icon.html
+++ b/djangocms_content_expiry/templates/djangocms_content_expiry/calendar_icon.html
@@ -1,2 +1,2 @@
 {% load static i18n %}
-<a class="btn cms-moderation-action-btn js-moderation-action related-widget-wrapper-link cms-versioning-action-btn" id="change_content_expiry_id_{{ field_id }}" href="{{ url }}" title="{% trans 'Additional Content Settings' %}"><span class="svg-juxtaposed-font"><img src="{% static 'djangocms_content_expiry/svg/file.svg' %}" /></span></a>
+<a class="btn cms-moderation-action-btn js-moderation-action related-widget-wrapper-link cms-versioning-action-btn" data-popup="yes" id="change_content_expiry_id_{{ field_id }}" href="{{ url }}" title="{% trans 'Additional Content Settings' %}"><span class="svg-juxtaposed-font"><img src="{% static 'djangocms_content_expiry/svg/file.svg' %}" /></span></a>


### PR DESCRIPTION
fix issue: https://github.com/FidelityInternational/djangocms-content-expiry/issues/3

When we click "additional content setting" in versions list, the setting dialog should be pop up, but now it's opened in the same window. When we click on the "save" button, the page can't be closed, but turn empty with a title "page closing... "

